### PR TITLE
Fix leftupdown bugs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vyos-vpn-agile (0.2.8) unstable; urgency=low
+
+  * add support for strongswan leftupdown script
+
+ -- Ralph Pillichshammer <c0defre4k@users.noreply.github.com>  Tue, 24 Jul 2018 08:11:01 +0000
+
 vyos-vpn-agile (0.2.7) unstable; urgency=low
 
   * Fix the bug where IPv6 subnets generate the wrong leftsubnet= output

--- a/lib/Vyatta/AgileConfig.pm
+++ b/lib/Vyatta/AgileConfig.pm
@@ -475,8 +475,10 @@ sub get_ra_conn {
   if (defined($self->{_x509_l_id})) {
      $server_id = "  leftid=" . $self->{_x509_l_id}. "\n";
   }
+  my $leftfirewall = "leftfirewall=yes";
   my $leftupdown;
   if (defined($self->{_left_updown})) {
+     $leftfirewall = "";
      $leftupdown = "  leftupdown=" . $self->{_left_updown}. "\n";
   }
   if (defined($self->{_x509_r_id})) {
@@ -511,7 +513,7 @@ ${auth_str}
   left=$oaddr
 ${server_id}
   leftsubnet=${left_subnet_route}
-  leftfirewall=yes
+${leftfirewall}  
   lefthostaccess=yes
 ${leftupdown}
   ike=${ike_str}${compat}

--- a/lib/Vyatta/AgileConfig.pm
+++ b/lib/Vyatta/AgileConfig.pm
@@ -33,6 +33,7 @@ my %fields = (
   _auth_mode        => undef,
   _oper_mode        => undef,
   _mtu              => undef,
+  _left_updown      => undef,
   _ike_lifetime     => undef,
   _inactivity       => undef,
   _ike_group        => undef,
@@ -474,6 +475,7 @@ sub get_ra_conn {
   if (defined($self->{_x509_l_id})) {
      $server_id = "  leftid=" . $self->{_x509_l_id}. "\n";
   }
+  my $leftupdown;
   if (defined($self->{_left_updown})) {
      $leftupdown = "  leftupdown=" . $self->{_left_updown}. "\n";
   }


### PR DESCRIPTION
This is a followup to #4 which fixes some bugs where variables where not initialized correctly. 
I also did some tests and fixed a problem where `leftupdown` can't be set along with `leftfirewall`.

I also bumped the version number for a new release. Maybe you can set a new Tag and link the .deb file. 